### PR TITLE
fix Unhandled Exception: setState() called after dispose()

### DIFF
--- a/lib/dart_image_slider.dart
+++ b/lib/dart_image_slider.dart
@@ -38,9 +38,11 @@ class _DartImageSliderState extends State<DartImageSlider> {
         targetWidth: widget.thumbWidth, targetHeight: widget.thumbHeight);
     ui.Image image = (await codec.getNextFrame()).image;
     myShape = MyShape(image: image);
-    setState(() {
-      _loading = false;
-    });
+    if (this.mounted) {
+      setState(() {
+        _loading = false;
+      });
+    }
   }
 
   // This widget is the root of your application.
@@ -51,10 +53,11 @@ class _DartImageSliderState extends State<DartImageSlider> {
         if (_loading) Container(),
         if (!_loading)
           Center(
-              child: SliderTheme(
-            data: SliderThemeData(thumbShape: myShape),
-            child: widget.slider,
-          )),
+            child: SliderTheme(
+              data: SliderThemeData(thumbShape: myShape),
+              child: widget.slider,
+            ),
+          ),
       ],
     );
   }


### PR DESCRIPTION
fix `Unhandled Exception: setState() called after dispose(): _DartImageSliderState#cd2bf(lifecycle state: defunct, not mounted)` by adding a mounted check; the issue usually occurs when other timed elements like animations are present on the same page as well. 